### PR TITLE
fix address save for latest hyva-checkout version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "magento2-module",
   "require": {
     "magento/framework": "*",
-    "hyva-themes/magento2-hyva-checkout": ">=1.1"
+    "hyva-themes/magento2-hyva-checkout": ">=1.3"
   },
   "authors": [
     {

--- a/src/Model/Form/EntityFormModifier/WithPostcodecheckModifier.php
+++ b/src/Model/Form/EntityFormModifier/WithPostcodecheckModifier.php
@@ -128,7 +128,7 @@ class WithPostcodecheckModifier implements EntityFormModifierInterface
 
         foreach ([$postcode, $housenumber, $addition, $manualMode] as $field) {
             if ($field) {
-                $field->setAttribute('@change.capture', '$wire.save()');
+                $field->setAttribute('@change.capture', '$wire.store');
             }
         }
     }


### PR DESCRIPTION
Fix address save for latest hyva-checkout version:

There were 2 issues after hyva-checkout updated:
- we cannot call $wire.save() according to new csp policy. It should be just $wire.save
- but if we use $wire.save -> it will pass an empty array as arguments to that method. But in `Hyva\Checkout\Magewire\Checkout\AddressView\AbstractMagewireAddressForm` this method requires bool argument, which also causes another error.

So as a workaround, I found that store() method will pass it and it has save() inside it :) 

This is going to be tested yet, so I'll merge it after that if approved.